### PR TITLE
fix: db.del not working

### DIFF
--- a/src/Database.ts
+++ b/src/Database.ts
@@ -479,16 +479,34 @@ export default class Database {
 
     let hasStatUpdate = false
     const stats = {} as GetStats
-    let result = this._memtable.get(lookupKey)
-    if (!result && !!this._immtable) {
-      result = this._immtable.get(lookupKey)
-    }
-    if (!result) {
-      const s = await current.get(lookupKey, stats)
-      hasStatUpdate = true
-      if (await s.ok()) {
-        result = (await s.promise) as Slice
+    let result: Slice | void = undefined
+    while (true) {
+      const memResult = this._memtable.get(lookupKey)
+      if (!!memResult) {
+        if (memResult.type === ValueType.kTypeValue) {
+          result = memResult.value
+        } else {
+          break
+        }
       }
+      if (!result && !!this._immtable) {
+        const immResult = this._immtable.get(lookupKey)
+        if (!!immResult) {
+          if (immResult.type === ValueType.kTypeValue) {
+            result = immResult.value
+          } else {
+            break
+          }
+        }
+      }
+      if (!result) {
+        const s = await current.get(lookupKey, stats)
+        hasStatUpdate = true
+        if (await s.ok()) {
+          result = (await s.promise) as Slice
+        }
+      }
+      break
     }
 
     if (hasStatUpdate && current.updateStats(stats)) {

--- a/src/Database.ts
+++ b/src/Database.ts
@@ -839,6 +839,28 @@ export default class Database {
         lastSequenceForKey = ikey.sn
       }
 
+      // used for debug
+      // if (
+      //   this._options.debug &&
+      //   ikey.valueType === ValueType.kTypeDeletion &&
+      //   !drop
+      // ) {
+      //   const snValueBig =
+      //     ikey.sn.value > compact.smallestSnapshot
+      //       ? 'key sequence is bigger then compact.smallestSnapshot. '
+      //       : ''
+      //   const isNotBaseLevel = !compact.compaction.isBaseLevelForKey(
+      //     ikey.userKey
+      //   )
+      //     ? 'this level is not base level for key. '
+      //     : ''
+      //   const becauseMsg = !drop ? `Because ${snValueBig}${isNotBaseLevel}` : ''
+      //   Log(
+      //     this._options.infoLog,
+      //     `${ikey.userKey} has been delete = ${drop}; ${becauseMsg}`
+      //   )
+      // }
+
       if (!drop) {
         // Open output file if necessary
         if (!compact.builder) {

--- a/src/Format.ts
+++ b/src/Format.ts
@@ -304,12 +304,16 @@ export function parseInternalKey(
   internalKey: Slice,
   ikey: ParsedInternalKey
 ): boolean {
-  ikey.userKey = extractUserKey(internalKey)
-  const snBuf = Buffer.alloc(8)
-  snBuf.fill(internalKey.buffer.slice(internalKey.length - 8), 0, 7)
-  ikey.sn = new SequenceNumber(decodeFixed64(snBuf))
-  ikey.valueType = internalKey.buffer[internalKey.length - 1]
-  return true
+  try {
+    ikey.userKey = extractUserKey(internalKey)
+    const snBuf = Buffer.alloc(8)
+    snBuf.fill(internalKey.buffer.slice(internalKey.length - 8), 0, 7)
+    ikey.sn = new SequenceNumber(decodeFixed64(snBuf))
+    ikey.valueType = internalKey.buffer[internalKey.length - 1]
+    return true
+  } catch (e) {
+    return false
+  }
 }
 
 export class LookupKey {

--- a/src/MemTable.ts
+++ b/src/MemTable.ts
@@ -141,7 +141,7 @@ export default class MemTable {
   // all entries with overly large sequence numbers.
   //
   // this key is lookup key
-  get(key: LookupKey): Slice | void {
+  get(key: LookupKey): Entry | void {
     const memkey = key.memKey
     const node = this._list.seek(memkey)
     if (!!node) {
@@ -153,10 +153,7 @@ export default class MemTable {
           key.userKey
         ) === 0
       ) {
-        const valueType = internalKey.type
-        if (valueType === ValueType.kTypeValue) {
-          return entry.value
-        }
+        return entry
       }
     }
   }

--- a/src/MemTable.ts
+++ b/src/MemTable.ts
@@ -14,6 +14,7 @@ import {
   InternalKeyComparator,
   LookupKey,
   Entry,
+  EntryRequireType,
   InternalKey,
 } from './Format'
 import Skiplist from './Skiplist'
@@ -141,7 +142,7 @@ export default class MemTable {
   // all entries with overly large sequence numbers.
   //
   // this key is lookup key
-  get(key: LookupKey): Entry | void {
+  get(key: LookupKey): EntryRequireType | void {
     const memkey = key.memKey
     const node = this._list.seek(memkey)
     if (!!node) {
@@ -153,7 +154,7 @@ export default class MemTable {
           key.userKey
         ) === 0
       ) {
-        return entry
+        return { key: entry.key, value: entry.value, type: internalKey.type }
       }
     }
   }

--- a/src/SSTable.ts
+++ b/src/SSTable.ts
@@ -181,10 +181,8 @@ export default class SSTable {
             entryInternalKey.userKey.isEqual(targetInternalKey.userKey) &&
             entryInternalKey.sequence <= targetInternalKey.sequence
           ) {
-            if (entryInternalKey.type === ValueType.kTypeValue) {
-              return new Status(Promise.resolve(entry))
-            }
-            break
+            // do not handle value type here, handle it at `Version.saveValue`
+            return new Status(Promise.resolve(entry))
           }
         }
       }


### PR DESCRIPTION
When delete a record, db insert a record with type `kTypeDeletion` in to `log` and `memtable`. This is woking. But `db.get` did not stop and keep seeking on immtable and table files.

Both memtable/immtable and table files shoud return record whenever value type is value or deletion.